### PR TITLE
fix typo and unlock import versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.x']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.x']
     
     steps:
       -

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,39 @@
+name: kskit Continuous Integration
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  codebase-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.x']
+    
+    steps:
+      -
+        name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      -
+        name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      -
+        name: Ensure Default Package Manager is up to date
+        run: python3 -m pip install --upgrade pip setuptools wheel
+      -
+        name: Install kskit prerequisites for Ubuntu
+        run: sudo apt-get install zbar-tools
+      -
+        name: Install kskit Package
+        run: |
+          cd kskit
+          pip install -e .[quality-tools]
+      -
+        name: Test with Pytest
+        run: pytest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,9 +31,7 @@ jobs:
         run: sudo apt-get install zbar-tools
       -
         name: Install kskit Package
-        run: |
-          cd kskit
-          pip install -e .[quality-tools]
+        run: pip install -e .[quality-tools]
       -
         name: Test with Pytest
         run: pytest

--- a/kskit/dicom/deid_mammogram.py
+++ b/kskit/dicom/deid_mammogram.py
@@ -323,7 +323,7 @@ def deidentify_attributes(indir: str, outdir: str, org_root: str, erase_outdir: 
         for attribute in df.columns:
             value = df[attribute][file]
             if attribute != 'FilePath':
-                df[attribute][file] = apply_deidentification(
+                df.loc[file, attribute] = apply_deidentification(
                     attribute,
                     value,
                     recipe,

--- a/kskit/dicom/get_dicom.py
+++ b/kskit/dicom/get_dicom.py
@@ -11,7 +11,7 @@ from pynetdicom.sop_class import (
     StudyRootQueryRetrieveInformationModelGet,
     PatientStudyOnlyQueryRetrieveInformationModelGet,
     PlannedImagingAgentAdministrationSRStorage,
-    PerformedImagingAgestAdministrationSRStorage,
+    PerformedImagingAgentAdministrationSRStorage,
     EncapsulatedSTLStorage,
 )
 

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,10 @@ setup(
         "fabric",
         "easyocr",
         "cryptography",
-        "easyocr==1.4.1",
-       # "torch==1.11.0",
-       # "torchvision==0.12.0"
-        "opencv-python==4.5.1.48",
-        "opencv-python-headless==4.5.1.48",
-        "pynetdicom",#==1.5.7",
+        "easyocr",  # ==1.4.1
+        "opencv-python",  # ==4.5.1.48
+        "opencv-python-headless",  # ==4.5.1.48
+        "pynetdicom",  # ==1.5.7",
         "Numpy",
         "matplotlib",
         "requests",


### PR DESCRIPTION
## What has changed?

- fix typo mistake in `get_dicom.py`
- unlock versions of dependencies (commenting old ones)
- change a dataframe operation to suppress pandas FutureWarning
```bash
FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
  You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy.
  A typical example is when you are setting values in a column of a DataFrame, like:
  
  df["col"][row_indexer] = value
  
  Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.
  
  See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  
    df[attribute][file] = apply_deidentification(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html 
```